### PR TITLE
fix. issues status re-opens on new incoming email

### DIFF
--- a/lib/mail_handler_patch.rb
+++ b/lib/mail_handler_patch.rb
@@ -39,6 +39,10 @@ module RedmineHelpdesk
             carbon_copy = nil
           end
 
+          if issue.closed?
+	    issue.status = IssueStatus.default
+	  end
+
           email_details << "Date: " + @email[:date].to_s + "\n"
           email_details = "<pre>\n" + Mail::Encodings.unquote_and_convert_to(email_details, 'utf-8') + "</pre>"
           issue.description = email_details + issue.description


### PR DESCRIPTION
Apply this simple patch https://www.redmine.org/attachments/5671/reopen_issue_on_email.patch which is discussed here https://www.redmine.org/issues/7994  as an issue in core redmine.

Here I'm just adding it to the other patching happening in this redmine_helpdesk plugin, and to the patching of the patching we're already doing
